### PR TITLE
Allow the cluster dropdown to be 600px high (previous 300px)

### DIFF
--- a/web/src/components/Dropdown/Dropdown.module.scss
+++ b/web/src/components/Dropdown/Dropdown.module.scss
@@ -63,7 +63,7 @@ $size: 40px;
     .options {
       overflow: hidden;
       overflow-y: auto;
-      max-height: 300px;
+      max-height: 600px;
       border-radius: inherit;
     }
   }


### PR DESCRIPTION
Fix #52