### PR TITLE
don't run as root / offical way for websocket upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,16 +176,11 @@ This is a minimalistic example configuration to configure apache as a reverse pr
 
 	ProxyRequests Off
 	ProxyPreserveHost On
-	ProxyPass / http://localhost:8000/
+	ProxyPass / http://localhost:8000/ upgrade=websocket
 	ProxyPassReverse / http://localhost:8000/
 
 	ErrorLog  /var/log/apache2/gnt-cc.example.com_error.log
 	CustomLog /var/log/apache2/gnt-cc.example.com_access.log
-
-	RewriteEngine on
-	RewriteCond %{HTTP:Upgrade} websocket [NC]
-	RewriteCond %{HTTP:Connection} upgrade [NC]
-	RewriteRule ^/?(.*) "ws://localhost:8000/$1" [P,L]
 </VirtualHost>
 ```
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,9 @@ ldapConfig:
 
 Please adapt the user and group search filters and base DN to your LDAP schema. You can use e.g. the `ldapsearch` tool to test filters on the commandline. `%s` will be substituted by `gnt-cc` with the username to be authenticated. If your LDAP server uses a self-signed TLS certificate (or the CA is unknown to your local CA trust store) you may set `skipCertificateVerify` to `true`.
 
-## Create a systemd service
+## Create a user and a systemd service
+
+Do not run `gnt-cc` as root, it's better to create a unique user for this service: `useradd -r -s /bin/false -d /non-existent gnt-cc`. Also set the permissions for the config directory containing passwords restrictive: `chown -Rh gnt-cc:gnt-cc /etc/gnt-cc/` and `chmod 0700 /etc/gnt-cc/`.
 
 You can use systemd to run `gnt-cc`. Please create the file `/etc/systemd/system/gnt-cc.service` with the following content:
 ```
@@ -139,6 +141,8 @@ You can use systemd to run `gnt-cc`. Please create the file `/etc/systemd/system
 Description=gnt-cc API server
 
 [Service]
+User=gnt-cc
+Group=gnt-cc
 Type=simple
 ExecStart=/usr/local/bin/gnt-cc
 


### PR DESCRIPTION
Do not run gnt-cc as root.

And use the worker option for websocket upgrade. Since Apache 2.4.47 the [ProxyPass worker supports](https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#wsupgrade) the option upgrade=websocket. Since I was unsuccessful to proxy the websocket for the console with the supplied Rewrite-method (the connection didn't upgrade and the ws client received HTTP status 200), I tried the built-in option with success. Maybe this is the way to go?